### PR TITLE
Fix code scanning alert no. 3: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
 		<java.version>21</java.version>
 	</properties>
 	<dependencies>
+	<dependency>
+	<groupId>org.apache.commons</groupId>
+	<artifactId>commons-text</artifactId>
+	<version>1.13.0</version>
+	</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>

--- a/src/main/java/com/example/management/app/AppController.java
+++ b/src/main/java/com/example/management/app/AppController.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
+import org.apache.commons.text.StringEscapeUtils;
 @Controller
 public class AppController {
     private final AppService appService;
@@ -61,6 +61,7 @@ public class AppController {
     @PostMapping("/make-admin/{email}")
     public ResponseEntity<String> makeAdmin(@PathVariable String email){
         appService.makeAdmin(email);
-        return ResponseEntity.ok(email.toUpperCase() + " is now Admin");
+        String safeEmail = StringEscapeUtils.escapeHtml4(email.toUpperCase());
+        return ResponseEntity.ok(safeEmail + " is now Admin");
     }
 }

--- a/src/main/java/com/example/management/app/AppController.java
+++ b/src/main/java/com/example/management/app/AppController.java
@@ -61,7 +61,7 @@ public class AppController {
     @PostMapping("/make-admin/{email}")
     public ResponseEntity<String> makeAdmin(@PathVariable String email){
         appService.makeAdmin(email);
-        String safeEmail = StringEscapeUtils.escapeHtml4(email.toUpperCase());
+        String safeEmail = StringEscapeUtils.escapeHtml4(email);
         return ResponseEntity.ok(safeEmail + " is now Admin");
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/Bajahaw/user-management/security/code-scanning/3](https://github.com/Bajahaw/user-management/security/code-scanning/3)

To fix the cross-site scripting vulnerability, we need to ensure that the user-provided `email` parameter is properly sanitized or encoded before being included in the response. The best way to fix this issue is to use a library that provides HTML encoding to escape any potentially harmful characters in the user input.

We will use the `StringEscapeUtils` class from the Apache Commons Text library to encode the `email` parameter before including it in the response. This will ensure that any special characters in the user input are properly escaped, preventing XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
